### PR TITLE
feat: add xAI provider and fix anthropic models always wrapping it's responses with ```

### DIFF
--- a/cmd/helix-assist/main.go
+++ b/cmd/helix-assist/main.go
@@ -62,6 +62,23 @@ func main() {
 		logger.Log("Registered Anthropic provider", "completion model:", cfg.AnthropicModel, "chat model:", chatModel)
 	}
 
+	if cfg.XAIKey != "" {
+		xaiProvider := providers.NewXAIProvider(
+			cfg.XAIKey,
+			cfg.XAIModel,
+			cfg.XAIModelForChat,
+			cfg.XAIEndpoint,
+			cfg.FetchTimeout,
+			logger,
+		)
+		registry.Register("xai", xaiProvider)
+		chatModel := cfg.XAIModelForChat
+		if chatModel == "" {
+			chatModel = cfg.XAIModel
+		}
+		logger.Log("Registered xAI provider", "completion model:", cfg.XAIModel, "chat model:", chatModel)
+	}
+
 	if err := registry.SetCurrent(cfg.Handler); err != nil {
 		fmt.Fprintf(os.Stderr, "Provider error: %s\n", err.Error())
 		os.Exit(1)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,10 @@ type Config struct {
 	AnthropicModel         string
 	AnthropicModelForChat  string
 	AnthropicEndpoint      string
+	XAIKey                 string
+	XAIModel               string
+	XAIModelForChat        string
+	XAIEndpoint            string
 	Debounce               int
 	TriggerCharacters      []string
 	NumSuggestions         int
@@ -38,6 +42,9 @@ func DefaultConfig() *Config {
 		AnthropicModel:         "claude-haiku-4-5",
 		AnthropicModelForChat:  "claude-sonnet-4-5",
 		AnthropicEndpoint:      "https://api.anthropic.com",
+		XAIModel:               "grok-4-1-fast-non-reasoning",
+		XAIModelForChat:        "grok-4-1-fast-non-reasoning",
+		XAIEndpoint:            "https://api.x.ai",
 		Debounce:               200,
 		TriggerCharacters:      []string{"{", "(", " "},
 		NumSuggestions:         1,
@@ -54,15 +61,19 @@ func Load() *Config {
 	cfg := DefaultConfig()
 
 	// Define flags
-	handler := flag.String("handler", getEnvOrDefault("HANDLER", cfg.Handler), "Provider: openai or anthropic")
+	handler := flag.String("handler", getEnvOrDefault("HANDLER", cfg.Handler), "Provider: openai, anthropic or xai")
 	openaiKey := flag.String("openai-key", getEnvOrDefault("OPENAI_API_KEY", ""), "OpenAI API key")
 	openaiModel := flag.String("openai-model", getEnvOrDefault("OPENAI_MODEL", cfg.OpenAIModel), "OpenAI model")
 	openaiEndpoint := flag.String("openai-endpoint", getEnvOrDefault("OPENAI_ENDPOINT", cfg.OpenAIEndpoint), "OpenAI API endpoint")
 	anthropicKey := flag.String("anthropic-key", getEnvOrDefault("ANTHROPIC_API_KEY", ""), "Anthropic API key")
 	anthropicModel := flag.String("anthropic-model", getEnvOrDefault("ANTHROPIC_MODEL", cfg.AnthropicModel), "Anthropic model")
 	anthropicEndpoint := flag.String("anthropic-endpoint", getEnvOrDefault("ANTHROPIC_ENDPOINT", cfg.AnthropicEndpoint), "Anthropic API endpoint")
+	xaiKey := flag.String("xai-key", getEnvOrDefault("XAI_API_KEY", ""), "xAI API key")
+	xaiModel := flag.String("xai-model", getEnvOrDefault("XAI_MODEL", cfg.XAIModel), "xAI model")
+	xaiEndpoint := flag.String("xai-endpoint", getEnvOrDefault("XAI_ENDPOINT", cfg.XAIEndpoint), "xAI API endpoint")
 	openaiModelForChat := flag.String("openai-model-for-chat", getEnvOrDefault("OPENAI_MODEL_FOR_CHAT", cfg.OpenAIModelForChat), "OpenAI model for chat actions (defaults to openai-model)")
 	anthropicModelForChat := flag.String("anthropic-model-for-chat", getEnvOrDefault("ANTHROPIC_MODEL_FOR_CHAT", cfg.AnthropicModelForChat), "Anthropic model for chat actions (defaults to anthropic-model)")
+	xaiModelForChat := flag.String("xai-model-for-chat", getEnvOrDefault("XAI_MODEL_FOR_CHAT", cfg.XAIModelForChat), "xAI model for chat actions (defaults to xai-model)")
 	debounce := flag.Int("debounce", getEnvOrDefaultInt("DEBOUNCE", cfg.Debounce), "Debounce delay (ms)")
 	triggerChars := flag.String("trigger-chars", getEnvOrDefault("TRIGGER_CHARACTERS", "{||(|| "), "Completion trigger characters (separated by ||)")
 	numSuggestions := flag.Int("num-suggestions", getEnvOrDefaultInt("NUM_SUGGESTIONS", cfg.NumSuggestions), "Number of suggestions")
@@ -85,6 +96,10 @@ func Load() *Config {
 	cfg.AnthropicModel = *anthropicModel
 	cfg.AnthropicModelForChat = *anthropicModelForChat
 	cfg.AnthropicEndpoint = *anthropicEndpoint
+	cfg.XAIKey = *xaiKey
+	cfg.XAIModel = *xaiModel
+	cfg.XAIModelForChat = *xaiModelForChat
+	cfg.XAIEndpoint = *xaiEndpoint
 	cfg.Debounce = *debounce
 	cfg.TriggerCharacters = strings.Split(*triggerChars, "||")
 	cfg.NumSuggestions = *numSuggestions
@@ -100,8 +115,8 @@ func Load() *Config {
 }
 
 func (c *Config) Validate() error {
-	if c.Handler != "openai" && c.Handler != "anthropic" {
-		return &ConfigError{Message: "handler must be 'openai' or 'anthropic'"}
+	if c.Handler != "openai" && c.Handler != "anthropic" && c.Handler != "xai" {
+		return &ConfigError{Message: "handler must be 'openai', 'anthropic' or 'xai'"}
 	}
 
 	if c.Handler == "openai" && c.OpenAIKey == "" {
@@ -112,8 +127,13 @@ func (c *Config) Validate() error {
 		return &ConfigError{Message: "Anthropic API key is required when using anthropic handler"}
 	}
 
+	if c.Handler == "xai" && c.XAIKey == "" {
+		return &ConfigError{Message: "xAI API key is required when using xai handler"}
+	}
+
 	return nil
 }
+
 
 type ConfigError struct {
 	Message string

--- a/internal/providers/openai.go
+++ b/internal/providers/openai.go
@@ -124,7 +124,7 @@ func (p *OpenAIProvider) Completion(ctx context.Context, req CompletionRequest, 
 			if output.Type == "message" {
 				for _, content := range output.Content {
 					if content.Type == "output_text" && content.Text != "" {
-						results = append(results, content.Text)
+						results = append(results, strings.TrimPrefix(content.Text, "CODE:"))
 					}
 				}
 			}

--- a/internal/providers/prompts.go
+++ b/internal/providers/prompts.go
@@ -12,6 +12,7 @@ Rules:
 - Do NOT repeat existing code
 - Do NOT include comments
 - Generate syntactically correct %s code that fits seamlessly between the before and after content
+- Your output MUST start with CODE:<newline> (followed by the newline)
 
 Context awareness:
 - CAREFULLY examine the code after the cursor - it shows what already exists

--- a/internal/providers/xai.go
+++ b/internal/providers/xai.go
@@ -14,7 +14,7 @@ import (
 	"github.com/leona/helix-assist/internal/util"
 )
 
-type AnthropicProvider struct {
+type XAIProvider struct {
 	apiKey    string
 	model     string
 	chatModel string
@@ -23,12 +23,14 @@ type AnthropicProvider struct {
 	logger    *lsp.Logger
 }
 
-func NewAnthropicProvider(apiKey, model, chatModel, endpoint string, timeoutMs int, logger *lsp.Logger) *AnthropicProvider {
+func NewXAIProvider(apiKey, model, chatModel, endpoint string, timeoutMs int, logger *lsp.Logger) *XAIProvider {
 	if chatModel == "" {
 		chatModel = model
 	}
-
-	return &AnthropicProvider{
+	if endpoint == "" {
+		endpoint = "https://api.x.ai"
+	}
+	return &XAIProvider{
 		apiKey:    apiKey,
 		model:     model,
 		chatModel: chatModel,
@@ -38,42 +40,31 @@ func NewAnthropicProvider(apiKey, model, chatModel, endpoint string, timeoutMs i
 	}
 }
 
-type anthropicMessage struct {
+type xaiMessage struct {
 	Role    string `json:"role"`
 	Content string `json:"content"`
 }
 
-type anthropicCacheControl struct {
-	Type string `json:"type"`
+type xaiRequest struct {
+	Model       string       `json:"model"`
+	MaxTokens   int          `json:"max_tokens"`
+	Messages    []xaiMessage `json:"messages"`
+	Temperature float64      `json:"temperature,omitempty"`
 }
 
-type anthropicSystemContent struct {
-	Type         string                 `json:"type"`
-	Text         string                 `json:"text"`
-	CacheControl *anthropicCacheControl `json:"cache_control,omitempty"`
+type xaiResponse struct {
+	Choices []struct {
+		Message struct {
+			Content string `json:"content"`
+		} `json:"message"`
+	} `json:"choices"`
 }
 
-type anthropicRequest struct {
-	Model       string                   `json:"model"`
-	MaxTokens   int                      `json:"max_tokens"`
-	System      []anthropicSystemContent `json:"system,omitempty"`
-	Messages    []anthropicMessage       `json:"messages"`
-	Temperature float64                  `json:"temperature,omitempty"`
-}
-
-type anthropicResponse struct {
-	Content []struct {
-		Type string `json:"type"`
-		Text string `json:"text"`
-	} `json:"content"`
-}
-
-func (p *AnthropicProvider) Completion(ctx context.Context, req CompletionRequest, filepath, languageID string, numSuggestions int) ([]string, error) {
+func (p *XAIProvider) Completion(ctx context.Context, req CompletionRequest, filepath, languageID string, numSuggestions int) ([]string, error) {
 	systemPrompt := BuildCompletionSystemPrompt(languageID)
 	userPrompt := BuildCompletionUserPrompt(filepath, req.ContentBefore, req.ContentAfter)
 
 	temperature := 0.0
-
 	if numSuggestions > 1 {
 		temperature = 0.4
 	}
@@ -81,24 +72,17 @@ func (p *AnthropicProvider) Completion(ctx context.Context, req CompletionReques
 	results := make([]string, 0, numSuggestions)
 
 	for i := 0; i < numSuggestions; i++ {
-		apiReq := anthropicRequest{
+		apiReq := xaiRequest{
 			Model:     p.model,
 			MaxTokens: 256,
-			System: []anthropicSystemContent{
-				{
-					Type:         "text",
-					Text:         systemPrompt,
-					CacheControl: &anthropicCacheControl{Type: "ephemeral"},
-				},
-			},
-			Temperature: temperature,
-			Messages: []anthropicMessage{
+			Messages: []xaiMessage{
+				{Role: "system", Content: systemPrompt},
 				{Role: "user", Content: userPrompt},
 			},
+			Temperature: temperature,
 		}
 
-		resp, err := p.doRequest(ctx, "/v1/messages", apiReq)
-
+		resp, err := p.doRequest(ctx, "/v1/chat/completions", apiReq)
 		if err != nil {
 			if len(results) > 0 {
 				break
@@ -106,8 +90,7 @@ func (p *AnthropicProvider) Completion(ctx context.Context, req CompletionReques
 			return nil, err
 		}
 
-		var apiResp anthropicResponse
-
+		var apiResp xaiResponse
 		if err := json.Unmarshal(resp, &apiResp); err != nil {
 			if len(results) > 0 {
 				break
@@ -115,9 +98,10 @@ func (p *AnthropicProvider) Completion(ctx context.Context, req CompletionReques
 			return nil, fmt.Errorf("parse response: %w", err)
 		}
 
-		for _, content := range apiResp.Content {
-			if content.Type == "text" && content.Text != "" {
-				results = append(results, strings.TrimPrefix(content.Text, "CODE:"))
+		for _, choice := range apiResp.Choices {
+			if choice.Message.Content != "" {
+				content := strings.TrimPrefix(choice.Message.Content, "CODE:")
+				results = append(results, content)
 			}
 		}
 	}
@@ -125,59 +109,47 @@ func (p *AnthropicProvider) Completion(ctx context.Context, req CompletionReques
 	return util.UniqueStrings(results), nil
 }
 
-func (p *AnthropicProvider) Chat(ctx context.Context, query, content, filepath, languageID string) (*ChatResponse, error) {
+func (p *XAIProvider) Chat(ctx context.Context, query, content, filepath, languageID string) (*ChatResponse, error) {
 	cleanFilepath := strings.TrimPrefix(filepath, "file://")
 
 	systemPrompt := BuildChatSystemPrompt(languageID)
 	userContent := BuildChatUserPrompt(languageID, cleanFilepath, content, query)
 
-	apiReq := anthropicRequest{
+	apiReq := xaiRequest{
 		Model:     p.chatModel,
 		MaxTokens: 8192,
-		System: []anthropicSystemContent{
-			{
-				Type: "text",
-				Text: systemPrompt,
-			},
-		},
-		Temperature: 0.1,
-		Messages: []anthropicMessage{
+		Messages: []xaiMessage{
+			{Role: "system", Content: systemPrompt},
 			{Role: "user", Content: userContent},
 		},
+		Temperature: 0.1,
 	}
 
 	jsonReq, _ := json.MarshalIndent(apiReq, "", "  ")
-	p.logger.Log("DEBUG [Anthropic Chat]: Request:", string(jsonReq))
+	p.logger.Log("DEBUG [XAI Chat]: Request:", string(jsonReq))
 
-	resp, err := p.doRequest(ctx, "/v1/messages", apiReq)
+	resp, err := p.doRequest(ctx, "/v1/chat/completions", apiReq)
 	if err != nil {
 		return nil, err
 	}
 
-	p.logger.Log("DEBUG [Anthropic Chat]: Raw response:", string(resp))
+	p.logger.Log("DEBUG [XAI Chat]: Raw response:", string(resp))
 
-	var apiResp anthropicResponse
+	var apiResp xaiResponse
 	if err := json.Unmarshal(resp, &apiResp); err != nil {
 		return nil, fmt.Errorf("parse response: %w", err)
 	}
 
-	if len(apiResp.Content) == 0 {
+	if len(apiResp.Choices) == 0 || apiResp.Choices[0].Message.Content == "" {
 		return nil, fmt.Errorf("no completion found")
 	}
 
-	var resultText string
-	for _, content := range apiResp.Content {
-		if content.Type == "text" {
-			resultText = content.Text
-			break
-		}
-	}
-
-	p.logger.Log("DEBUG [Anthropic Chat]: Extracted text:", resultText)
-	return &ChatResponse{Result: resultText}, nil
+	text := apiResp.Choices[0].Message.Content
+	p.logger.Log("DEBUG [XAI Chat]: Extracted text:", text)
+	return &ChatResponse{Result: text}, nil
 }
 
-func (p *AnthropicProvider) doRequest(ctx context.Context, endpoint string, body any) ([]byte, error) {
+func (p *XAIProvider) doRequest(ctx context.Context, endpoint string, body any) ([]byte, error) {
 	jsonBody, err := json.Marshal(body)
 	if err != nil {
 		return nil, fmt.Errorf("marshal request: %w", err)
@@ -193,8 +165,7 @@ func (p *AnthropicProvider) doRequest(ctx context.Context, endpoint string, body
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("x-api-key", p.apiKey)
-	req.Header.Set("anthropic-version", "2023-06-01")
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
I added xAI provider and fixed the issue with claude wrapping its responses with ```.

From my testing, I can say that both Anthropic and xAI perform terribly for some reason, but I'm not sure why it is happening. Maybe something to do with the way how requests are sent? Maybe using something like https://github.com/plexusone/omnillm should make sense, it allows adding new providers MUCH easier and is preconfigured properly. At the very least, it'll cut the code lines heavily since it provides a uniform API for all supported providers.

As it stands now, only OpenAI has more or less of a nice experience. Both Anthropic, and xAI providers are quite lacking.

Anthropic models always insert ``` despite the prompt. Notibly, xAI models do this too but even worse. My idea with the `CODE:<newline>` prefix actually worked. It's weird, no matter how hard I tried to prohibit `claude` and `grok` from using triple backticks, they ignored all my instructions.