### PR TITLE
Ollama provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A Go port of the [helix-gpt](https://github.com/leona/helix-gpt) language server
 
 - **OpenAI** (default)
 - **Anthropic**
+- **Ollama** (local models with FIM support)
 
 ## Installation
 
@@ -76,8 +77,12 @@ Add to `~/.config/helix/languages.toml`:
 ```toml
 [language-server.helix-assist]
 command = "helix-assist"
-# Optional
-args = ["--handler", "anthropic", "--num-suggestions", "2"]
+# Example 1: Anthropic
+# args = ["--handler", "anthropic", "--num-suggestions", "2"]
+# Example 2: Local Ollama (Qwen2.5-Coder)
+# args = ["--handler", "ollama", "--ollama-model", "qwen2.5-coder:7b"]
+# Disable FIM mode
+# args = ["--handler", "ollama", "--ollama-model", "qwen2.5-coder:7b", "--ollama-disable-fim"]
 
 [[language]]
 name = "go"
@@ -104,13 +109,17 @@ language-servers = ["pylsp", "helix-assist"]
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `HANDLER` | `openai` | Provider: `openai` or `anthropic` |
+| `HANDLER` | `openai` | Provider: `openai`, `anthropic`, or `ollama` |
 | `OPENAI_API_KEY` | - | OpenAI API key |
 | `OPENAI_MODEL` | `gpt-4.1-mini` | OpenAI model for completions |
 | `OPENAI_ENDPOINT` | `https://api.openai.com/v1` | OpenAI API endpoint |
 | `ANTHROPIC_API_KEY` | - | Anthropic API key |
 | `ANTHROPIC_MODEL` | `claude-sonnet-4-5` | Anthropic model |
 | `ANTHROPIC_ENDPOINT` | `https://api.anthropic.com` | Anthropic API endpoint |
+| `OLLAMA_ENDPOINT` | `http://localhost:11434` | Ollama API endpoint |
+| `OLLAMA_MODEL` | `qwen2.5-coder` | Ollama model for completions |
+| `OLLAMA_MODEL_FOR_CHAT` | `qwen2.5-coder` | Ollama model for chat actions |
+| `OLLAMA_DISABLE_FIM` | `false` | Disable FIM mode for completions |
 | `DEBOUNCE` | `200` | Debounce delay in milliseconds |
 | `TRIGGER_CHARACTERS` | `{`\|\|`(`\|\|` ` | Completion triggers (separated by `\|\|`) |
 | `NUM_SUGGESTIONS` | `1` | Number of completion suggestions |

--- a/cmd/helix-assist-test/main.go
+++ b/cmd/helix-assist-test/main.go
@@ -16,7 +16,7 @@ import (
 func main() {
 	testDir := flag.String("testdir", "", "Directory containing test files")
 	testFile := flag.String("file", "", "Single test file to run")
-	provider := flag.String("provider", "openai", "Provider to use (openai or anthropic)")
+	provider := flag.String("provider", "openai", "Provider to use (openai, anthropic, or ollama)")
 	language := flag.String("language", "", "Filter tests by language (optional)")
 	numSuggestions := flag.Int("num-suggestions", 1, "Number of completions to request")
 	timeoutMs := flag.Int("timeout", 15000, "Completion timeout in milliseconds")
@@ -24,11 +24,18 @@ func main() {
 
 	openaiKey := flag.String("openai-key", os.Getenv("OPENAI_API_KEY"), "OpenAI API key")
 	openaiModel := flag.String("openai-model", getEnvOrDefault("OPENAI_MODEL", "gpt-4.1-mini"), "OpenAI model")
+	openaiModelForChat := flag.String("openai-model-for-chat", getEnvOrDefault("OPENAI_MODEL_FOR_CHAT", ""), "OpenAI chat model")
 	openaiEndpoint := flag.String("openai-endpoint", getEnvOrDefault("OPENAI_ENDPOINT", "https://api.openai.com/v1"), "OpenAI API endpoint")
 
 	anthropicKey := flag.String("anthropic-key", os.Getenv("ANTHROPIC_API_KEY"), "Anthropic API key")
 	anthropicModel := flag.String("anthropic-model", getEnvOrDefault("ANTHROPIC_MODEL", "claude-sonnet-4-5"), "Anthropic model")
+	anthropicModelForChat := flag.String("anthropic-model-for-chat", getEnvOrDefault("ANTHROPIC_MODEL_FOR_CHAT", ""), "Anthropic chat model")
 	anthropicEndpoint := flag.String("anthropic-endpoint", getEnvOrDefault("ANTHROPIC_ENDPOINT", "https://api.anthropic.com"), "Anthropic API endpoint")
+
+	ollamaEndpoint := flag.String("ollama-endpoint", getEnvOrDefault("OLLAMA_ENDPOINT", "http://localhost:11434"), "Ollama API endpoint")
+	ollamaModel := flag.String("ollama-model", getEnvOrDefault("OLLAMA_MODEL", "qwen2.5-coder"), "Ollama model")
+	ollamaModelForChat := flag.String("ollama-model-for-chat", getEnvOrDefault("OLLAMA_MODEL_FOR_CHAT", "qwen2.5-coder"), "Ollama chat model")
+	ollamaDisableFIM := flag.Bool("ollama-disable-fim", false, "Disable FIM")
 
 	flag.Parse()
 
@@ -44,8 +51,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	if *provider != "openai" && *provider != "anthropic" {
-		fmt.Fprintf(os.Stderr, "Error: Provider must be 'openai' or 'anthropic'\n")
+	if *provider != "openai" && *provider != "anthropic" && *provider != "ollama" {
+		fmt.Fprintf(os.Stderr, "Error: Provider must be 'openai', 'anthropic', or 'ollama'\n")
 		os.Exit(1)
 	}
 
@@ -62,6 +69,7 @@ func main() {
 		openaiProvider := providers.NewOpenAIProvider(
 			*openaiKey,
 			*openaiModel,
+			*openaiModelForChat,
 			*openaiEndpoint,
 			*timeoutMs,
 			logger,
@@ -79,12 +87,27 @@ func main() {
 		anthropicProvider := providers.NewAnthropicProvider(
 			*anthropicKey,
 			*anthropicModel,
+			*anthropicModelForChat,
 			*anthropicEndpoint,
 			*timeoutMs,
 			logger,
 		)
 		registry.Register("anthropic", anthropicProvider)
 		if err := registry.SetCurrent("anthropic"); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+	} else if *provider == "ollama" {
+		ollamaProvider := providers.NewOllamaProvider(
+			*ollamaModel,
+			*ollamaModelForChat,
+			*ollamaEndpoint,
+			*ollamaDisableFIM,
+			*timeoutMs,
+			logger,
+		)
+		registry.Register("ollama", ollamaProvider)
+		if err := registry.SetCurrent("ollama"); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}

--- a/cmd/helix-assist/main.go
+++ b/cmd/helix-assist/main.go
@@ -62,6 +62,23 @@ func main() {
 		logger.Log("Registered Anthropic provider", "completion model:", cfg.AnthropicModel, "chat model:", chatModel)
 	}
 
+	if cfg.OllamaModel != "" || cfg.Handler == "ollama" {
+		ollamaProvider := providers.NewOllamaProvider(
+			cfg.OllamaModel,
+			cfg.OllamaModelForChat,
+			cfg.OllamaEndpoint,
+			cfg.OllamaDisableFIM,
+			cfg.FetchTimeout,
+			logger,
+		)
+		registry.Register("ollama", ollamaProvider)
+		chatModel := cfg.OllamaModelForChat
+		if chatModel == "" {
+			chatModel = cfg.OllamaModel
+		}
+		logger.Log("Registered Ollama provider", "completion model:", cfg.OllamaModel, "chat model:", chatModel)
+	}
+
 	if err := registry.SetCurrent(cfg.Handler); err != nil {
 		fmt.Fprintf(os.Stderr, "Provider error: %s\n", err.Error())
 		os.Exit(1)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,10 @@ type Config struct {
 	AnthropicModel         string
 	AnthropicModelForChat  string
 	AnthropicEndpoint      string
+	OllamaEndpoint         string
+	OllamaModel            string
+	OllamaModelForChat     string
+	OllamaDisableFIM       bool
 	Debounce               int
 	TriggerCharacters      []string
 	NumSuggestions         int
@@ -38,6 +42,10 @@ func DefaultConfig() *Config {
 		AnthropicModel:         "claude-haiku-4-5",
 		AnthropicModelForChat:  "claude-sonnet-4-5",
 		AnthropicEndpoint:      "https://api.anthropic.com",
+		OllamaEndpoint:         "http://localhost:11434",
+		OllamaModel:            "qwen2.5-coder",
+		OllamaModelForChat:     "",
+		OllamaDisableFIM:       false,
 		Debounce:               200,
 		TriggerCharacters:      []string{"{", "(", " "},
 		NumSuggestions:         1,
@@ -54,7 +62,7 @@ func Load() *Config {
 	cfg := DefaultConfig()
 
 	// Define flags
-	handler := flag.String("handler", getEnvOrDefault("HANDLER", cfg.Handler), "Provider: openai or anthropic")
+	handler := flag.String("handler", getEnvOrDefault("HANDLER", cfg.Handler), "Provider: openai, anthropic, or ollama")
 	openaiKey := flag.String("openai-key", getEnvOrDefault("OPENAI_API_KEY", ""), "OpenAI API key")
 	openaiModel := flag.String("openai-model", getEnvOrDefault("OPENAI_MODEL", cfg.OpenAIModel), "OpenAI model")
 	openaiEndpoint := flag.String("openai-endpoint", getEnvOrDefault("OPENAI_ENDPOINT", cfg.OpenAIEndpoint), "OpenAI API endpoint")
@@ -63,6 +71,10 @@ func Load() *Config {
 	anthropicEndpoint := flag.String("anthropic-endpoint", getEnvOrDefault("ANTHROPIC_ENDPOINT", cfg.AnthropicEndpoint), "Anthropic API endpoint")
 	openaiModelForChat := flag.String("openai-model-for-chat", getEnvOrDefault("OPENAI_MODEL_FOR_CHAT", cfg.OpenAIModelForChat), "OpenAI model for chat actions (defaults to openai-model)")
 	anthropicModelForChat := flag.String("anthropic-model-for-chat", getEnvOrDefault("ANTHROPIC_MODEL_FOR_CHAT", cfg.AnthropicModelForChat), "Anthropic model for chat actions (defaults to anthropic-model)")
+	ollamaEndpoint := flag.String("ollama-endpoint", getEnvOrDefault("OLLAMA_ENDPOINT", cfg.OllamaEndpoint), "Ollama API endpoint")
+	ollamaModel := flag.String("ollama-model", getEnvOrDefault("OLLAMA_MODEL", cfg.OllamaModel), "Ollama model")
+	ollamaModelForChat := flag.String("ollama-model-for-chat", getEnvOrDefault("OLLAMA_MODEL_FOR_CHAT", cfg.OllamaModelForChat), "Ollama model for chat actions")
+	ollamaDisableFIM := flag.Bool("ollama-disable-fim", getEnvOrDefaultBool("OLLAMA_DISABLE_FIM", cfg.OllamaDisableFIM), "Disable FIM for completions and use instruct mode")
 	debounce := flag.Int("debounce", getEnvOrDefaultInt("DEBOUNCE", cfg.Debounce), "Debounce delay (ms)")
 	triggerChars := flag.String("trigger-chars", getEnvOrDefault("TRIGGER_CHARACTERS", "{||(|| "), "Completion trigger characters (separated by ||)")
 	numSuggestions := flag.Int("num-suggestions", getEnvOrDefaultInt("NUM_SUGGESTIONS", cfg.NumSuggestions), "Number of suggestions")
@@ -85,6 +97,10 @@ func Load() *Config {
 	cfg.AnthropicModel = *anthropicModel
 	cfg.AnthropicModelForChat = *anthropicModelForChat
 	cfg.AnthropicEndpoint = *anthropicEndpoint
+	cfg.OllamaEndpoint = *ollamaEndpoint
+	cfg.OllamaModel = *ollamaModel
+	cfg.OllamaModelForChat = *ollamaModelForChat
+	cfg.OllamaDisableFIM = *ollamaDisableFIM
 	cfg.Debounce = *debounce
 	cfg.TriggerCharacters = strings.Split(*triggerChars, "||")
 	cfg.NumSuggestions = *numSuggestions
@@ -100,8 +116,8 @@ func Load() *Config {
 }
 
 func (c *Config) Validate() error {
-	if c.Handler != "openai" && c.Handler != "anthropic" {
-		return &ConfigError{Message: "handler must be 'openai' or 'anthropic'"}
+	if c.Handler != "openai" && c.Handler != "anthropic" && c.Handler != "ollama" {
+		return &ConfigError{Message: "handler must be 'openai', 'anthropic', or 'ollama'"}
 	}
 
 	if c.Handler == "openai" && c.OpenAIKey == "" {

--- a/internal/providers/ollama.go
+++ b/internal/providers/ollama.go
@@ -1,0 +1,222 @@
+package providers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/leona/helix-assist/internal/lsp"
+	"github.com/leona/helix-assist/internal/util"
+)
+
+type OllamaProvider struct {
+	model      string
+	chatModel  string
+	endpoint   string
+	disableFIM bool
+	timeout    time.Duration
+	logger     *lsp.Logger
+}
+
+func NewOllamaProvider(model, chatModel, endpoint string, disableFIM bool, timeoutMs int, logger *lsp.Logger) *OllamaProvider {
+	if chatModel == "" {
+		chatModel = model
+	}
+	return &OllamaProvider{
+		model:      model,
+		chatModel:  chatModel,
+		endpoint:   strings.TrimSuffix(endpoint, "/"),
+		disableFIM: disableFIM,
+		timeout:    time.Duration(timeoutMs) * time.Millisecond,
+		logger:     logger,
+	}
+}
+
+type ollamaGenerateRequest struct {
+	Model   string                 `json:"model"`
+	Prompt  string                 `json:"prompt"`
+	Suffix  string                 `json:"suffix,omitempty"`
+	System  string                 `json:"system,omitempty"`
+	Raw     bool                   `json:"raw,omitempty"`
+	Stream  bool                   `json:"stream"`
+	Options map[string]interface{} `json:"options,omitempty"`
+}
+
+type ollamaGenerateResponse struct {
+	Response string `json:"response"`
+}
+
+type ollamaMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type ollamaChatRequest struct {
+	Model    string                 `json:"model"`
+	Messages []ollamaMessage        `json:"messages"`
+	Stream   bool                   `json:"stream"`
+	Options  map[string]interface{} `json:"options,omitempty"`
+}
+
+type ollamaChatResponse struct {
+	Message ollamaMessage `json:"message"`
+}
+
+func (p *OllamaProvider) Completion(ctx context.Context, req CompletionRequest, filepath, languageID string, numSuggestions int) ([]string, error) {
+	temperature := 0.0
+	if numSuggestions > 1 {
+		temperature = 0.4
+	}
+
+	results := make([]string, 0, numSuggestions)
+
+	for i := 0; i < numSuggestions; i++ {
+		var apiReq ollamaGenerateRequest
+		if p.disableFIM {
+			apiReq = ollamaGenerateRequest{
+				Model:   p.model,
+				Prompt:  BuildCompletionUserPrompt(filepath, req.ContentBefore, req.ContentAfter),
+				System:  BuildCompletionSystemPrompt(languageID),
+				Raw:     false,
+				Stream:  false,
+				Options: map[string]interface{}{
+					"temperature": temperature,
+					"num_predict": 256,
+				},
+			}
+		} else {
+			// Native FIM by providing prompt and suffix
+			apiReq = ollamaGenerateRequest{
+				Model:   p.model,
+				Prompt:  req.ContentBefore,
+				Suffix:  req.ContentAfter,
+				Raw:     true,
+				Stream:  false,
+				Options: map[string]interface{}{
+					"temperature": temperature,
+					"num_predict": 256,
+					"stop": []string{"<|fim_prefix|>", "<|fim_suffix|>", "<|fim_middle|>", "<|file_sep|>", "<|endoftext|>"},
+				},
+			}
+		}
+
+		resp, err := p.doRequest(ctx, "/api/generate", apiReq)
+		if err != nil {
+			if len(results) > 0 {
+				break
+			}
+			return nil, err
+		}
+
+		var apiResp ollamaGenerateResponse
+		if err := json.Unmarshal(resp, &apiResp); err != nil {
+			if len(results) > 0 {
+				break
+			}
+			return nil, fmt.Errorf("parse response: %w", err)
+		}
+
+		if apiResp.Response != "" {
+			cleanResponse := stripMarkdown(apiResp.Response)
+			results = append(results, cleanResponse)
+		}
+	}
+
+	return util.UniqueStrings(results), nil
+}
+
+func stripMarkdown(text string) string {
+	// 1. Remove the leading ```language tag (and optional whitespace/newline)
+	reStart := regexp.MustCompile("(?i)^\\s*```[a-z0-9+\\-]*\\s*\\n?")
+	text = reStart.ReplaceAllString(text, "")
+	
+	// 2. Remove the trailing ``` (and optional newline)
+	reEnd := regexp.MustCompile("\\n?\\s*```\\s*$")
+	text = reEnd.ReplaceAllString(text, "")
+	
+	return text
+}
+
+func (p *OllamaProvider) Chat(ctx context.Context, query, content, filepath, languageID string) (*ChatResponse, error) {
+	cleanFilepath := strings.TrimPrefix(filepath, "file://")
+
+	systemPrompt := BuildChatSystemPrompt(languageID)
+	userContent := BuildChatUserPrompt(languageID, cleanFilepath, content, query)
+
+	apiReq := ollamaChatRequest{
+		Model:  p.chatModel,
+		Stream: false,
+		Messages: []ollamaMessage{
+			{Role: "system", Content: systemPrompt},
+			{Role: "user", Content: userContent},
+		},
+		Options: map[string]interface{}{
+			"temperature": 0.1,
+		},
+	}
+
+	jsonReq, _ := json.MarshalIndent(apiReq, "", "  ")
+	p.logger.Log("DEBUG [Ollama Chat]: Request:", string(jsonReq))
+
+	resp, err := p.doRequest(ctx, "/api/chat", apiReq)
+	if err != nil {
+		return nil, err
+	}
+
+	p.logger.Log("DEBUG [Ollama Chat]: Raw response:", string(resp))
+
+	var apiResp ollamaChatResponse
+	if err := json.Unmarshal(resp, &apiResp); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	if apiResp.Message.Content == "" {
+		return nil, fmt.Errorf("no completion found")
+	}
+
+	cleanResponse := stripMarkdown(apiResp.Message.Content)
+
+	p.logger.Log("DEBUG [Ollama Chat]: Extracted text:", cleanResponse)
+	return &ChatResponse{Result: cleanResponse}, nil
+}
+
+func (p *OllamaProvider) doRequest(ctx context.Context, endpoint string, body any) ([]byte, error) {
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, p.timeout)
+	defer cancel()
+
+	url := p.endpoint + endpoint
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	return respBody, nil
+}

--- a/internal/providers/prompts.go
+++ b/internal/providers/prompts.go
@@ -7,6 +7,7 @@ func BuildCompletionSystemPrompt(languageID string) string {
 
 Rules:
 - Output ONLY the code that should be inserted at the cursor position
+- CRITICAL: Do NOT wrap your response in Markdown code blocks. Do not use backticks (`+"```"+`). Do not include any conversational filler, explanations, or text outside of the raw code.
 - Do NOT include any code that already exists before or after the cursor
 - Do NOT add explanations, comments, or markdown formatting
 - Do NOT repeat existing code
@@ -45,6 +46,7 @@ func BuildChatSystemPrompt(languageID string) string {
 
 Rules:
 - Output ONLY the corrected/improved code that should replace the selection
+- CRITICAL: Do NOT wrap your response in Markdown code blocks. Do not use backticks (`+"```"+`). Do not include any conversational filler, explanations, or text outside of the raw code.
 - DO NOT include explanations, markdown formatting, or code block delimiters
 - DO NOT include any text before or after the code
 - DO NOT add extra comments unless specifically requested


### PR DESCRIPTION
This PR adds a new provider for Ollama, supporting both FIM completions and ordinary chat actions (refactoring/diagnostics), allowing `helix-assist` to run entirely offline with local models like `qwen2.5-coder`

### Code Changes
 - **New Ollama Provider (`internal/providers/ollama.go`)**: Implemented a dedicated provider that natively hooks into Ollama's `/api/generate` and `/api/chat` endpoints.
 - **FIM vs Instruct toggling**: By default, completions utilize Ollama's native Fill-In-The-Middle feature by sending `Prompt` and `Suffix`. For slower hardware, a `--ollama-disable-fim` flag was added to wrap the context in a standard instruct prompt instead.
 - **Bulletproof Markdown Stripping**: Instruct models often wrap code inside Markdown blocks (e.g. ` ```javascript `) even when explicitly told not to. Added a robust regular expression `stripMarkdown` helper that intercepts and cleans up Ollama's responses before sending them back to Helix.
 - **Stop Tokens**: Added standard FIM stop tokens (`<|fim_prefix|>`, `<|fim_suffix|>`, `<|file_sep|>`, etc.) to the local `/api/generate` request options to prevent the model from generating run-on content outside the bounds of the cursor insertion.
 - **Aggressive Prompt Constraints (`internal/providers/prompts.go`)**: Fortified the base system prompts to aggressively forbid backticks and conversational filler during chat actions.
 - **Configuration & Wiring (`internal/config/config.go`, `cmd/helix-assist/main.go`)**: Added new CLI flags and environment variables (`OLLAMA_ENDPOINT`, `OLLAMA_MODEL`, `OLLAMA_MODEL_FOR_CHAT`, `OLLAMA_DISABLE_FIM`). Wired the new provider into the main service registry.