### PR TITLE
fix: add missing chatModel param in test binary provider constructors

### DIFF
--- a/cmd/helix-assist-test/main.go
+++ b/cmd/helix-assist-test/main.go
@@ -62,6 +62,7 @@ func main() {
 		openaiProvider := providers.NewOpenAIProvider(
 			*openaiKey,
 			*openaiModel,
+			"",
 			*openaiEndpoint,
 			*timeoutMs,
 			logger,
@@ -79,6 +80,7 @@ func main() {
 		anthropicProvider := providers.NewAnthropicProvider(
 			*anthropicKey,
 			*anthropicModel,
+			"",
 			*anthropicEndpoint,
 			*timeoutMs,
 			logger,


### PR DESCRIPTION
Commit e420780 added a chatModel parameter to NewOpenAIProvider and NewAnthropicProvider, but the test binary was not updated to match. This caused a compilation error. This PR adds the missing empty-string argument to both provider constructor calls.