### PR TITLE
feat: make OpenAI service_tier configurable via flag and env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ language-servers = ["pylsp", "helix-assist"]
 | `OPENAI_API_KEY` | - | OpenAI API key |
 | `OPENAI_MODEL` | `gpt-4.1-mini` | OpenAI model for completions |
 | `OPENAI_ENDPOINT` | `https://api.openai.com/v1` | OpenAI API endpoint |
+| `OPENAI_SERVICE_TIER` | `priority` | OpenAI service tier |
 | `ANTHROPIC_API_KEY` | - | Anthropic API key |
 | `ANTHROPIC_MODEL` | `claude-sonnet-4-5` | Anthropic model |
 | `ANTHROPIC_ENDPOINT` | `https://api.anthropic.com` | Anthropic API endpoint |

--- a/cmd/helix-assist-test/main.go
+++ b/cmd/helix-assist-test/main.go
@@ -25,6 +25,7 @@ func main() {
 	openaiKey := flag.String("openai-key", os.Getenv("OPENAI_API_KEY"), "OpenAI API key")
 	openaiModel := flag.String("openai-model", getEnvOrDefault("OPENAI_MODEL", "gpt-4.1-mini"), "OpenAI model")
 	openaiEndpoint := flag.String("openai-endpoint", getEnvOrDefault("OPENAI_ENDPOINT", "https://api.openai.com/v1"), "OpenAI API endpoint")
+	openaiServiceTier := flag.String("openai-service-tier", getEnvOrDefault("OPENAI_SERVICE_TIER", "priority"), "OpenAI service tier")
 
 	anthropicKey := flag.String("anthropic-key", os.Getenv("ANTHROPIC_API_KEY"), "Anthropic API key")
 	anthropicModel := flag.String("anthropic-model", getEnvOrDefault("ANTHROPIC_MODEL", "claude-sonnet-4-5"), "Anthropic model")
@@ -63,6 +64,7 @@ func main() {
 			*openaiKey,
 			*openaiModel,
 			*openaiEndpoint,
+			*openaiServiceTier,
 			*timeoutMs,
 			logger,
 		)

--- a/cmd/helix-assist/main.go
+++ b/cmd/helix-assist/main.go
@@ -34,6 +34,7 @@ func main() {
 			cfg.OpenAIModel,
 			cfg.OpenAIModelForChat,
 			cfg.OpenAIEndpoint,
+			cfg.OpenAIServiceTier,
 			cfg.FetchTimeout,
 			logger,
 		)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	OpenAIModel            string
 	OpenAIModelForChat     string
 	OpenAIEndpoint         string
+	OpenAIServiceTier      string
 	AnthropicKey           string
 	AnthropicModel         string
 	AnthropicModelForChat  string
@@ -35,6 +36,7 @@ func DefaultConfig() *Config {
 		OpenAIModel:            "gpt-4.1",
 		OpenAIModelForChat:     "gpt-5",
 		OpenAIEndpoint:         "https://api.openai.com/v1",
+		OpenAIServiceTier:      "priority",
 		AnthropicModel:         "claude-haiku-4-5",
 		AnthropicModelForChat:  "claude-sonnet-4-5",
 		AnthropicEndpoint:      "https://api.anthropic.com",
@@ -58,6 +60,7 @@ func Load() *Config {
 	openaiKey := flag.String("openai-key", getEnvOrDefault("OPENAI_API_KEY", ""), "OpenAI API key")
 	openaiModel := flag.String("openai-model", getEnvOrDefault("OPENAI_MODEL", cfg.OpenAIModel), "OpenAI model")
 	openaiEndpoint := flag.String("openai-endpoint", getEnvOrDefault("OPENAI_ENDPOINT", cfg.OpenAIEndpoint), "OpenAI API endpoint")
+	openaiServiceTier := flag.String("openai-service-tier", getEnvOrDefault("OPENAI_SERVICE_TIER", cfg.OpenAIServiceTier), "OpenAI service tier (auto, default, flex, on_demand, performance)")
 	anthropicKey := flag.String("anthropic-key", getEnvOrDefault("ANTHROPIC_API_KEY", ""), "Anthropic API key")
 	anthropicModel := flag.String("anthropic-model", getEnvOrDefault("ANTHROPIC_MODEL", cfg.AnthropicModel), "Anthropic model")
 	anthropicEndpoint := flag.String("anthropic-endpoint", getEnvOrDefault("ANTHROPIC_ENDPOINT", cfg.AnthropicEndpoint), "Anthropic API endpoint")
@@ -81,6 +84,7 @@ func Load() *Config {
 	cfg.OpenAIModel = *openaiModel
 	cfg.OpenAIModelForChat = *openaiModelForChat
 	cfg.OpenAIEndpoint = *openaiEndpoint
+	cfg.OpenAIServiceTier = *openaiServiceTier
 	cfg.AnthropicKey = *anthropicKey
 	cfg.AnthropicModel = *anthropicModel
 	cfg.AnthropicModelForChat = *anthropicModelForChat

--- a/internal/providers/openai.go
+++ b/internal/providers/openai.go
@@ -26,29 +26,31 @@ var reasoningModels = map[string]bool{
 }
 
 type OpenAIProvider struct {
-	apiKey    string
-	model     string
-	chatModel string
-	endpoint  string
-	timeout   time.Duration
-	logger    *lsp.Logger
+	apiKey      string
+	model       string
+	chatModel   string
+	endpoint    string
+	serviceTier string
+	timeout     time.Duration
+	logger      *lsp.Logger
 }
 
 func isReasoningModel(model string) bool {
 	return reasoningModels[model]
 }
 
-func NewOpenAIProvider(apiKey, model, chatModel, endpoint string, timeoutMs int, logger *lsp.Logger) *OpenAIProvider {
+func NewOpenAIProvider(apiKey, model, chatModel, endpoint, serviceTier string, timeoutMs int, logger *lsp.Logger) *OpenAIProvider {
 	if chatModel == "" {
 		chatModel = model
 	}
 	return &OpenAIProvider{
-		apiKey:    apiKey,
-		model:     model,
-		chatModel: chatModel,
-		endpoint:  strings.TrimSuffix(endpoint, "/"),
-		timeout:   time.Duration(timeoutMs) * time.Millisecond,
-		logger:    logger,
+		apiKey:      apiKey,
+		model:       model,
+		chatModel:   chatModel,
+		endpoint:    strings.TrimSuffix(endpoint, "/"),
+		serviceTier: serviceTier,
+		timeout:     time.Duration(timeoutMs) * time.Millisecond,
+		logger:      logger,
 	}
 }
 
@@ -90,7 +92,7 @@ func (p *OpenAIProvider) Completion(ctx context.Context, req CompletionRequest, 
 			Instructions: instructions,
 			Input:        userPrompt,
 			Store:        false,
-			ServiceTier:  "priority",
+			ServiceTier:  p.serviceTier,
 			MaxToolCalls: 0,
 			Metadata: map[string]interface{}{
 				"language": languageID,
@@ -145,7 +147,7 @@ func (p *OpenAIProvider) Chat(ctx context.Context, query, content, filepath, lan
 		Instructions: instructions,
 		Input:        userContent,
 		Store:        false,
-		ServiceTier:  "priority",
+		ServiceTier:  p.serviceTier,
 		MaxToolCalls: 0,
 		Metadata: map[string]interface{}{
 			"language": languageID,


### PR DESCRIPTION
The service_tier field was hardcoded to priority, which some API providers (e.g. Groq) do not support. This PR makes it configurable via: --openai-service-tier CLI flag OPENAI_SERVICE_TIER env var. Default remains priority to preserve existing behavior.