### PR TITLE
fix: code actions for partial selections

### DIFF
--- a/internal/handlers/actions.go
+++ b/internal/handlers/actions.go
@@ -55,13 +55,30 @@ func (h *ActionHandler) Register(svc *lsp.Service) {
 		}
 
 		svc.Buffers.SetCurrentURI(params.TextDocument.URI)
+
+		content := svc.Buffers.GetContentFromRange(params.TextDocument.URI, params.Range)
+		if strings.TrimSpace(content) == "" {
+			svc.Send(&lsp.JSONRPCMessage{
+				ID:     msg.ID,
+				Result: []lsp.CodeAction{},
+			})
+			return
+		}
+
 		actions := make([]lsp.CodeAction, 0, len(Commands))
 
 		for _, cmd := range Commands {
 			diagnosticMsgs := make([]string, 0, len(params.Context.Diagnostics))
 
 			for _, d := range params.Context.Diagnostics {
+				if !rangesOverlap(d.Range, params.Range) {
+					continue
+				}
 				diagnosticMsgs = append(diagnosticMsgs, d.Message)
+			}
+
+			if cmd.Key == "resolveDiagnostics" && len(diagnosticMsgs) == 0 {
+				continue
 			}
 
 			actions = append(actions, lsp.CodeAction{
@@ -127,12 +144,14 @@ func (h *ActionHandler) executeCommand(svc *lsp.Service, msg *lsp.JSONRPCMessage
 	}
 
 	query := cmdArg.Query
+	extendRange := false
 
 	for _, cmd := range Commands {
 		if cmd.Key == params.Command {
 			if query == "" {
 				query = cmd.Query
 			}
+			extendRange = cmd.Key == "resolveDiagnostics"
 			break
 		}
 	}
@@ -154,7 +173,12 @@ func (h *ActionHandler) executeCommand(svc *lsp.Service, msg *lsp.JSONRPCMessage
 		svc.SendShowMessage(lsp.MessageTypeInfo, "Executing "+params.Command+"...")
 	}
 
-	content := svc.Buffers.GetContentFromRange(currentURI, cmdArg.Range)
+	editRange := cmdArg.Range
+	if extendRange {
+		editRange = extendToFullLines(cmdArg.Range)
+	}
+
+	content := svc.Buffers.GetContentFromRange(currentURI, editRange)
 	padding := util.GetContentPadding(content)
 
 	buffer, ok := svc.Buffers.Get(currentURI)
@@ -214,7 +238,7 @@ func (h *ActionHandler) executeCommand(svc *lsp.Service, msg *lsp.JSONRPCMessage
 				Changes: map[string][]lsp.TextEdit{
 					currentURI: {
 						{
-							Range:   cmdArg.Range,
+							Range:   editRange,
 							NewText: result,
 						},
 					},
@@ -231,3 +255,28 @@ func mustMarshal(v any) json.RawMessage {
 	}
 	return data
 }
+
+func rangesOverlap(a, b lsp.Range) bool {
+	if a.Start.Line > b.End.Line || b.Start.Line > a.End.Line {
+		return false
+	}
+	if a.End.Line < b.Start.Line || b.End.Line < a.Start.Line {
+		return false
+	}
+	return true
+}
+
+func extendToFullLines(r lsp.Range) lsp.Range {
+	start := r.Start
+	end := r.End
+	start.Character = 0
+	if start.Line == end.Line && r.Start.Character == r.End.Character {
+		end.Line = start.Line + 1
+		end.Character = 0
+	} else if end.Character != 0 {
+		end.Line++
+		end.Character = 0
+	}
+	return lsp.Range{Start: start, End: end}
+}
+

--- a/internal/lsp/buffer.go
+++ b/internal/lsp/buffer.go
@@ -98,6 +98,42 @@ func (s *BufferStore) GetContentFromRange(uri string, r Range) string {
 		endLine = len(lines) - 1
 	}
 
-	selectedLines := lines[r.Start.Line : endLine+1]
-	return strings.Join(selectedLines, "\n")
+	if r.Start.Line == endLine && r.Start.Character == r.End.Character {
+		return lines[r.Start.Line]
+	}
+
+	if r.Start.Line == endLine {
+		start := r.Start.Character
+		end := r.End.Character
+		if start > len(lines[r.Start.Line]) {
+			start = len(lines[r.Start.Line])
+		}
+		if end > len(lines[r.Start.Line]) {
+			end = len(lines[r.Start.Line])
+		}
+		return lines[r.Start.Line][start:end]
+	}
+
+	result := make([]string, 0, endLine-r.Start.Line+1)
+	firstLine := lines[r.Start.Line]
+	startChar := r.Start.Character
+	if startChar > len(firstLine) {
+		startChar = len(firstLine)
+	}
+	result = append(result, firstLine[startChar:])
+
+	for i := r.Start.Line + 1; i < endLine; i++ {
+		result = append(result, lines[i])
+	}
+
+	lastLine := lines[endLine]
+	endChar := r.End.Character
+	if endChar > len(lastLine) {
+		endChar = len(lastLine)
+	}
+	if endChar > 0 {
+		result = append(result, lastLine[:endChar])
+	}
+
+	return strings.Join(result, "\n")
 }


### PR DESCRIPTION
## Problem

Code actions (especially "Resolve diagnostics") were broken when the selection didn't cover full lines:

1. **All file diagnostics were sent to the LLM** regardless of selection, causing duplicate/extra code when the LLM tried to fix unrelated diagnostics
2. **`GetContentFromRange` always extracted full lines** even for partial selections, creating a mismatch between the content sent to the LLM and the edit range applied
3. **"Resolve diagnostics" was offered even with no matching diagnostics** on the selected line
4. **Code actions were offered on empty lines**, causing unnecessary LLM calls

## Changes

**`internal/lsp/buffer.go` — `GetContentFromRange`**

Rewritten to respect character-level selection:
- Zero-width range (cursor only) returns the full line
- Single-line partial selection returns the exact substring
- Multi-line selection splices partial first line + full middle lines + partial last line
- Skips the last line when `End.Character == 0`

**`internal/handlers/actions.go` — `EventCodeAction` handler**

- Returns no actions when the selected range is empty/whitespace
- Filters diagnostics by range overlap for all commands
- Skips `resolveDiagnostics` entirely when no diagnostics overlap the selection

**`internal/handlers/actions.go` — `executeCommand`**

- For `resolveDiagnostics`: expands the selection to full lines via `extendToFullLines` so the LLM gets complete line context and the replacement covers the whole line
- For `improveCode` and `refactorFromComment`: uses the exact selection range

**`internal/handlers/actions.go` — new helpers**

- `rangesOverlap(a, b Range) bool` — checks if two LSP ranges overlap
- `extendToFullLines(r Range) Range` — snaps a range to full line boundaries, handling zero-width selections

## Behavior

| Scenario | Before | After |
|---|---|---|
| Cursor on empty line | All 3 actions offered | No actions offered |
| Partial selection, no diagnostics | All 3 actions offered | `improveCode` + `refactorFromComment` only |
| Partial selection, diagnostics on selected lines | All 3 actions, all file diagnostics sent | `resolveDiagnostics` + others, only matching diagnostics |
| `resolveDiagnostics` with partial selection | LLM receives partial line, edit range mismatches | Full lines extracted and replaced |
| `improveCode` with partial selection | Full lines extracted, edit range mismatches | Exact selection extracted and replaced |
