### PR TITLE
feat: add configurable context truncation for completions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> Graduated from autocomplete to full AI agents? Check out [kb](https://github.com/leona/kb) — a shared knowledge base for Claude Code, Codex, and OpenCode.
+> Graduated from autocomplete to full AI agents? Check out [kb](https://github.com/leona/kb) - a shared knowledge base for Claude Code, Codex, and OpenCode.
 
 # helix-assist
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> Graduated from autocomplete to full AI agents? Check out [kb](https://github.com/leona/kb) — a shared knowledge base for Claude Code, Codex, and OpenCode.
+
 # helix-assist
 
 ![Build Status](https://github.com/leona/helix-assist/actions/workflows/release.yml/badge.svg)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,7 +32,7 @@ type Config struct {
 func DefaultConfig() *Config {
 	return &Config{
 		Handler:                "openai",
-		OpenAIModel:            "gpt-4.1-mini",
+		OpenAIModel:            "gpt-4.1",
 		OpenAIModelForChat:     "gpt-5",
 		OpenAIEndpoint:         "https://api.openai.com/v1",
 		AnthropicModel:         "claude-haiku-4-5",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	FetchTimeout           int
 	ActionTimeout          int
 	CompletionTimeout      int
+	MaxContextChars         int
 	DebugQuery             string
 	EnableProgressSpinner  bool
 	ProgressUpdateInterval int
@@ -44,6 +45,7 @@ func DefaultConfig() *Config {
 		FetchTimeout:           15000,
 		ActionTimeout:          15000,
 		CompletionTimeout:      15000,
+		MaxContextChars:         0,
 		EnableProgressSpinner:  true,
 		ProgressUpdateInterval: 200,
 	}
@@ -70,6 +72,7 @@ func Load() *Config {
 	fetchTimeout := flag.Int("fetch-timeout", getEnvOrDefaultInt("FETCH_TIMEOUT", cfg.FetchTimeout), "Fetch timeout (ms)")
 	actionTimeout := flag.Int("action-timeout", getEnvOrDefaultInt("ACTION_TIMEOUT", cfg.ActionTimeout), "Action timeout (ms)")
 	completionTimeout := flag.Int("completion-timeout", getEnvOrDefaultInt("COMPLETION_TIMEOUT", cfg.CompletionTimeout), "Completion timeout (ms)")
+	maxContextChars := flag.Int("max-context-chars", getEnvOrDefaultInt("MAX_CONTEXT_CHARS", cfg.MaxContextChars), "Max context characters for completions (0 = no limit)")
 	debugQuery := flag.String("debug-query", "", "Debug mode: test provider with a query and exit")
 	enableProgressSpinner := flag.Bool("enable-progress-spinner", getEnvOrDefaultBool("ENABLE_PROGRESS_SPINNER", cfg.EnableProgressSpinner), "Enable animated progress spinner")
 	progressUpdateInterval := flag.Int("progress-update-interval", getEnvOrDefaultInt("PROGRESS_UPDATE_INTERVAL", cfg.ProgressUpdateInterval), "Progress update interval (ms)")
@@ -92,6 +95,7 @@ func Load() *Config {
 	cfg.FetchTimeout = *fetchTimeout
 	cfg.ActionTimeout = *actionTimeout
 	cfg.CompletionTimeout = *completionTimeout
+	cfg.MaxContextChars = *maxContextChars
 	cfg.DebugQuery = *debugQuery
 	cfg.EnableProgressSpinner = *enableProgressSpinner
 	cfg.ProgressUpdateInterval = *progressUpdateInterval

--- a/internal/handlers/completions.go
+++ b/internal/handlers/completions.go
@@ -100,8 +100,10 @@ func (h *CompletionHandler) doCompletion(svc *lsp.Service, msg *lsp.JSONRPCMessa
 		}
 	}
 
+	contentBefore, contentAfter := util.TruncateContext(content.ContentBefore, contentAfter, h.cfg.MaxContextChars)
+
 	hints, err := h.registry.Completion(ctx, providers.CompletionRequest{
-		ContentBefore: content.ContentBefore,
+		ContentBefore: contentBefore,
 		ContentAfter:  contentAfter,
 	}, params.TextDocument.URI, buffer.LanguageID, h.cfg.NumSuggestions)
 

--- a/internal/util/content.go
+++ b/internal/util/content.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"strconv"
 	"strings"
 )
 
@@ -96,6 +97,46 @@ func PadContent(text string, padding int) string {
 	}
 
 	return strings.Join(lines, "\n")
+}
+
+func TruncateContext(before, after string, maxChars int) (string, string) {
+	if maxChars <= 0 {
+		return before, after
+	}
+
+	total := len(before) + len(after)
+	if total <= maxChars {
+		return before, after
+	}
+
+	excess := total - maxChars
+	beforeLen := len(before)
+
+	removeBefore := excess * beforeLen / total
+	removeAfter := excess - removeBefore
+
+	if removeBefore > 0 {
+		start := removeBefore
+		if idx := strings.Index(before[start:], "\n"); idx >= 0 {
+			start += idx
+		}
+		before = "// ... [truncated " + strconv.Itoa(removeBefore) + " chars]\n" + before[start:]
+	}
+
+	if removeAfter > 0 {
+		end := len(after) - removeAfter
+		if end > 0 {
+			beforeCut := after[:end]
+			if idx := strings.LastIndex(beforeCut, "\n"); idx >= 0 {
+				end = idx + 1
+			}
+		} else {
+			end = 0
+		}
+		after = after[:end] + "\n// ... [truncated " + strconv.Itoa(removeAfter) + " chars]"
+	}
+
+	return before, after
 }
 
 func UniqueStrings(items []string) []string {


### PR DESCRIPTION
Adds \--max-context-chars\ flag (default 0 = no truncation) to limit the amount of file content sent in completion requests. Useful for providers with strict token-per-minute rate limits like Groq free tier.

Trims proportionally from the far ends (start of file, end of file) when the combined \ContentBefore\ + \ContentAfter\ exceeds the budget, keeping the text closest to the cursor intact.